### PR TITLE
Improve templating for the georeference service

### DIFF
--- a/service_geo/README.md
+++ b/service_geo/README.md
@@ -103,7 +103,7 @@ In production the service is only requested through a TYPO3 proxy layer. This me
       <td align="left">https://github.com/slub/kartenforum_georeference</td>
       <td align="left">Url to the git repository. Make sure that the git repository is public or that your ssh agent supports `-o ForwardAgent=yes`.</td>
     </tr> 
-        <tr>
+    <tr>
       <td align="left">service.git_repo.branch</td>
       <td align="left">main</td>
       <td align="left">Branch of the git repository to checkout.</td>
@@ -113,6 +113,34 @@ In production the service is only requested through a TYPO3 proxy layer. This me
       <td align="left">True</td>
       <td align="left">If `True` it uses the git repository for code checkout. As an alternative for developing setups, set it to `False` and place the code as an `tar.gz` archive under the path `roles/geoerference/files/georeference.tar.gz`.</td>
     </tr>
+    <tr>
+      <td align="left">service.settings.global_permalink_resolver</td>
+      <td align="left">http://digital.slub-dresden.de</td>
+      <td align="left">Url of the global permalink resolver.</td>
+    </tr>
+    <tr>
+      <td align="left">service.settings.template_links_tms</td>
+      <ul>
+        <li>https://tms-1.kartenforum.slub-dresden.de/%s</li>
+        <li>https://tms-1.kartenforum.slub-dresden.de/%s</li>
+      </ul>
+      <td align="left">Template string which is used from the Python Code to generate the TMS-Links. `%s` is an expression, which can be used from Python to resolve template strings.</td>
+    </tr>   
+    <tr>
+      <td align="left">service.settings.template_link_wms</td>
+      <td align="left">https://wms.kartenforum.slub-dresden.de/map/%s</td>
+      <td align="left">Template string which is used from the Python Code to generate the WMS-Links. `%s` is an expression, which can be used from Python to resolve template strings.</td>
+    </tr>   
+    <tr>
+      <td align="left">service.settings.template_link_wms_transform</td>
+      <td align="left">https://wms-transform.kartenforum.slub-dresden.de/map/%s</td>
+      <td align="left">Template string which is used from the Python Code to generate the temporary WMS-Links. `%s` is an expression, which can be used from Python to resolve template strings.</td>
+    </tr> 
+    <tr>
+      <td align="left">service.settings.template_link_wcs</td>
+      <td align="left">https://wcs.kartenforum.slub-dresden.de/map/%s</td>
+      <td align="left">Template string which is used from the Python Code to generate the WCS-Links. `%s` is an expression, which can be used from Python to resolve template strings.</td>
+    </tr>           
     <tr>
       <td align="left">search.domain</td>
       <td align="left">search.kartenforum.slub-dresden.de</td>

--- a/service_geo/main.yml
+++ b/service_geo/main.yml
@@ -38,6 +38,14 @@
         url: https://github.com/slub/kartenforum_georeference
         branch: develop-prerelease
       use_git_repo: True
+      settings:
+        global_permalink_resolver: http://digital.slub-dresden.de/
+        template_links_tms:
+          - https://tms-1.kartenforum.slub-dresden.de/%s
+          - https://tms-2.kartenforum.slub-dresden.de/%s
+        template_link_wms: https://wms.kartenforum.slub-dresden.de/map/%s
+        template_link_wms_transform: https://wms-transform.kartenforum.slub-dresden.de/map/%s
+        template_link_wcs: https://wcs.kartenforum.slub-dresden.de/map/%s
     search:
       domain: search.kartenforum.slub-dresden.de
       port: 443

--- a/service_geo/roles/georeference/templates/settings.py.j2
+++ b/service_geo/roles/georeference/templates/settings.py.j2
@@ -29,7 +29,7 @@ GLOBAL_PATH_GDALWARP = 'gdalwarp'
 GLOBAL_PATH_GDALADDO = 'gdaladdo'
 
 # Permalink resolver
-GLOBAL_PERMALINK_RESOLVER = 'http://digital.slub-dresden.de/'
+GLOBAL_PERMALINK_RESOLVER = '{{ service.settings.global_permalink_resolver }}/'
 
 # Number of processes used for creating the tms
 GLOBAL_TMS_PROCESSES = 2
@@ -84,8 +84,9 @@ PATH_TMP_TRANSFORMATION_DATA_ROOT = '{{ storage.directories.mapfile_tmp_root }}/
 
 # Georeference TMS Cache url
 TEMPLATE_TMS_URLS = [
-    'https://tms-1.kartenforum.slub-dresden.de/%s',
-    'https://tms-2.kartenforum.slub-dresden.de/%s'
+{% for link in service.settings.template_links_tms %}
+    {{ link }}{{ ", " if not loop.last else "" }}
+{% endfor %}
 ]
 
 #
@@ -105,13 +106,13 @@ SRC_DICT_WKT = {
 #
 
 # Template for the public wms service
-TEMPLATE_PUBLIC_WMS_URL = 'https://wms.kartenforum.slub-dresden.de/map/%s'
+TEMPLATE_PUBLIC_WMS_URL = '{{ service.settings.template_link_wms }}'
 
 # Template for the public wms service
-TEMPLATE_PUBLIC_WCS_URL = 'https://wcs.kartenforum.slub-dresden.de/map/%s'
+TEMPLATE_PUBLIC_WCS_URL = '{{ service.settings.template_link_wcs }}'
 
 # WMS Service default url template
-TEMPLATE_TRANSFORMATION_WMS_URL = 'https://wms-transform.kartenforum.slub-dresden.de/map/%s?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.0.0'
+TEMPLATE_TRANSFORMATION_WMS_URL = '{{ service.settings.template_link_wms_transform }}?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.0.0'
 
 # Template for proper building of ids
 TEMPLATE_OAI_ID = 'oai:de:slub-dresden:vk:id-%s'


### PR DESCRIPTION
The pull-request contains minor improvements on the `service_geo/main.yml`. It allows the settings of WMS and WCS template links as well as the configuration of the template links for the TMSs. 

